### PR TITLE
mleHousing.py nested run for Model

### DIFF
--- a/mlflowhousing.py
+++ b/mlflowhousing.py
@@ -77,13 +77,17 @@ if __name__ == "__main__":
 
     # Read the wine-quality csv file (make sure you're running this from the root of MLflow!)
     data_path = "data/housing.csv"
-    train_x, train_y, test_x, test_y = load_data(data_path)
+
 
     c = float(sys.argv[1]) if len(sys.argv) > 1 else 30000.0
     k = str(sys.argv[2]) if len(sys.argv) > 2 else "linear"
 
     with mlflow.start_run(run_name="PARENT_RUN") as parent_run:
         mlflow.log_param("parent", "yes")
+        with mlflow.start_run(run_name="CHILD_RUN_DataLoad", nested=True) as child_run:
+            mlflow.log_param("child_DataLoad", "yes")
+            train_x, train_y, test_x, test_y = load_data(data_path)
+
         with mlflow.start_run(run_name="CHILD_RUN", nested=True) as child_run:
             mlflow.log_param("child", "yes")
             lr = SVR(C=c, kernel=k)

--- a/mlflowhousing.py
+++ b/mlflowhousing.py
@@ -1,0 +1,109 @@
+import sys
+import warnings
+
+import mlflow
+import mlflow.sklearn
+import numpy as np
+import pandas as pd
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import ElasticNet
+from sklearn.svm import SVR
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import StratifiedShuffleSplit, train_test_split
+
+
+def eval_metrics(actual, pred):
+    rmse = np.sqrt(mean_squared_error(actual, pred))
+    mae = mean_absolute_error(actual, pred)
+    r2 = r2_score(actual, pred)
+    return rmse, mae, r2
+
+
+def load_data(data_path):
+    data = pd.read_csv(data_path)
+
+    data["income_cat"] = pd.cut(
+        data["median_income"],
+        bins=[0.0, 1.5, 3.0, 4.5, 6.0, np.inf],
+        labels=[1, 2, 3, 4, 5],
+    )
+
+    data["rooms_per_household"] = data["total_rooms"] / data["households"]
+    data["bedrooms_per_room"] = data["total_bedrooms"] / data["total_rooms"]
+    data["population_per_household"] = data["population"] / data["households"]
+
+    imputer = SimpleImputer(strategy="median")
+
+    housing_num = data.drop("ocean_proximity", axis=1)
+
+    imputer.fit(housing_num)
+    X = imputer.transform(housing_num)
+
+    housing_tr = pd.DataFrame(X, columns=housing_num.columns, index=data.index)
+    housing_tr["rooms_per_household"] = (
+        housing_tr["total_rooms"] / housing_tr["households"]
+    )
+    housing_tr["bedrooms_per_room"] = (
+        housing_tr["total_bedrooms"] / housing_tr["total_rooms"]
+    )
+    housing_tr["population_per_household"] = (
+        housing_tr["population"] / housing_tr["households"]
+    )
+
+    housing_cat = data[["ocean_proximity"]]
+    data = housing_tr.join(pd.get_dummies(housing_cat, drop_first=True))
+
+    # Split the data into training and test sets. (0.75, 0.25) split
+    split = StratifiedShuffleSplit(n_splits=1, test_size=0.25, random_state=42)
+
+    for train_index, test_index in split.split(data, data["income_cat"]):
+        strat_train_set = data.loc[train_index]
+        strat_test_set = data.loc[test_index]
+
+    for set_ in (strat_train_set, strat_test_set):
+        set_.drop("income_cat", axis=1, inplace=True)
+
+    train_x = strat_train_set.drop("median_house_value", axis=1)
+    test_x = strat_test_set.drop("median_house_value", axis=1)
+    train_y = strat_train_set["median_house_value"]
+    test_y = strat_test_set["median_house_value"]
+
+    return train_x, train_y, test_x, test_y
+
+
+if __name__ == "__main__":
+    warnings.filterwarnings("ignore")
+    np.random.seed(40)
+
+    # Read the wine-quality csv file (make sure you're running this from the root of MLflow!)
+    data_path = "data/housing.csv"
+    train_x, train_y, test_x, test_y = load_data(data_path)
+
+    c = float(sys.argv[1]) if len(sys.argv) > 1 else 30000.0
+    k = str(sys.argv[2]) if len(sys.argv) > 2 else "linear"
+
+    with mlflow.start_run(run_name="PARENT_RUN") as parent_run:
+        mlflow.log_param("parent", "yes")
+        with mlflow.start_run(run_name="CHILD_RUN", nested=True) as child_run:
+            mlflow.log_param("child", "yes")
+            lr = SVR(C=c, kernel=k)
+            lr.fit(train_x, train_y)
+
+            predicted_qualities = lr.predict(test_x)
+
+            (rmse, mae, r2) = eval_metrics(test_y, predicted_qualities)
+
+            print("SVR model (C=%f, Kernal=%f):" % (c, k))
+            print("  RMSE: %s" % rmse)
+
+            print("  MAE: %s" % mae)
+            print("  R2: %s" % r2)
+
+            mlflow.log_param("C", c)
+            mlflow.log_param("Kernal", k)
+
+            mlflow.log_metric("rmse", rmse)
+            mlflow.log_metric("r2", r2)
+            mlflow.log_metric("mae", mae)
+
+            mlflow.sklearn.log_model(lr, "model")


### PR DESCRIPTION
Implemented mlflow to track the parameters for housing library code. Create a main script that runs everything together under a single parent mlflow run-id. Each of the child tasks (i.e. data preparation, model training etc) should get their own mlflow run-id but run as child runs of the main run.